### PR TITLE
Add HTTP transport support for Smithery.ai deployment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,5 +10,6 @@ dependencies = [
     "python-dotenv>=1.0.1",
     "typing-extensions>=4.12.2",
     "PyMySQL==1.1.0",
-    "asyncio==3.4.3"
+    "asyncio==3.4.3",
+    "uvicorn>=0.27.0"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ python-dotenv>=1.0.0    # For loading environment variables from .env file
 logging>=0.4.9.6        # Enhanced logging capabilities
 typing-extensions>=4.5.0 # For advanced type hints
 asyncio==3.4.3
-PyMySQL==1.1.0 
+PyMySQL==1.1.0
+uvicorn>=0.27.0         # ASGI server for HTTP transport mode 

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,6 +1,7 @@
 # Smithery.ai configuration
 startCommand:
-  type: stdio
+  type: http
+  endpoint: /mcp
   configSchema:
     # JSON Schema defining the configuration options for the MCP.
     type: "object"
@@ -11,19 +12,16 @@ startCommand:
         description: "Your SkySQL API key for accessing SkySQL services"
     required: ["skysqlApiKey"]
   commandFunction:
-    # A function that produces the CLI command to start the MCP on stdio.
+    # A function that produces the CLI command to start the MCP on HTTP.
     |-
     (config) => ({
       "command": "python",
       "args": [
-        "mcp-server/server.py"
+        "mcp-server/server_http.py"
       ],
       "env": {
-        "MCP_HOST": "0.0.0.0",
-        "MCP_PORT": "8000",
-        "MCP_DEBUG": "False",
+        "SKYSQL_API_KEY": config.skysqlApiKey,
         "MCP_SECRET_KEY": "${SECRET_KEY}",
-        "MCP_API_KEYS": "${API_KEYS}",
-        "SKYSQL_API_KEY": config.skysqlApiKey
+        "MCP_API_KEYS": "${API_KEYS}"
       }
     })

--- a/src/mcp-server/server.py
+++ b/src/mcp-server/server.py
@@ -438,15 +438,15 @@ async def execute_sql(service_id: str, sql_query: str) -> str:
 # Update the main block with enhanced error handling and Windows compatibility
 if __name__ == "__main__":
     try:
-        logger.info("Starting SkySQL MCP Server...")
+        logger.info("Starting SkySQL MCP Server (stdio mode)...")
         logger.info(f"Python version: {sys.version}")
 
-            # Ensure stdin/stdout are in binary mode for Windows compatibility
+        # Ensure stdin/stdout are in binary mode for Windows compatibility
         if sys.platform == "win32":
             import msvcrt
             msvcrt.setmode(sys.stdin.fileno(), os.O_BINARY)
             msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
-        # Run the server
+        # Run the server in stdio mode
         mcp.run()
     except Exception as e:
         logger.error(f"Error starting server: {str(e)}", exc_info=True)

--- a/src/mcp-server/server_http.py
+++ b/src/mcp-server/server_http.py
@@ -1,0 +1,64 @@
+"""
+HTTP transport entry point for SkySQL MCP Server.
+This file is used for HTTP-based deployments (e.g., Smithery.ai).
+For local stdio usage, use server.py instead.
+"""
+import os
+import sys
+import logging
+from dotenv import load_dotenv
+
+# Ensure we can import from the same directory
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+# Import the mcp instance from server.py
+from server import mcp
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.FileHandler('skysql_mcp_server.log'),
+        logging.StreamHandler(sys.stderr)
+    ]
+)
+logger = logging.getLogger(__name__)
+
+# Load environment variables from .env file
+load_dotenv()
+
+if __name__ == "__main__":
+    try:
+        import uvicorn
+        
+        logger.info("Starting SkySQL MCP Server (HTTP mode)...")
+        logger.info(f"Python version: {sys.version}")
+        
+        host = os.getenv("MCP_HOST", "0.0.0.0")
+        # Smithery sets PORT environment variable, fallback to MCP_PORT for local testing
+        port = int(os.getenv("PORT", os.getenv("MCP_PORT", "8000")))
+        logger.info(f"Starting HTTP server on {host}:{port}")
+        
+        # FastMCP exposes the HTTP app via .http_app() method
+        try:
+            app = mcp.http_app()
+        except AttributeError:
+            logger.error("FastMCP http_app method not found. FastMCP may not support HTTP transport in this version.")
+            logger.error("Available attributes: " + ", ".join([attr for attr in dir(mcp) if not attr.startswith('_')]))
+            sys.exit(1)
+        except Exception as e:
+            logger.error(f"Error calling http_app(): {str(e)}")
+            sys.exit(1)
+        
+        uvicorn.run(app, host=host, port=port, log_level="info")
+    except ImportError as e:
+        logger.error(f"Missing required dependency: {str(e)}")
+        logger.error("Please install uvicorn: pip install uvicorn>=0.27.0")
+        sys.exit(1)
+    except Exception as e:
+        logger.error(f"Error starting server: {str(e)}", exc_info=True)
+        sys.exit(1)
+    finally:
+        logger.info("Server shutting down...")
+


### PR DESCRIPTION
- Add server_http.py as HTTP entry point using FastMCP http_app()
- Update smithery.yaml to use HTTP transport with endpoint /mcp
- Revert server.py to stdio-only mode for local desktop use
- Add uvicorn dependency for HTTP server
- Include Smithery authentication variables (MCP_SECRET_KEY, MCP_API_KEYS)